### PR TITLE
Bug answer box

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -150,7 +150,7 @@ class App extends React.Component {
         </Tab>
         <Tab eventKey='testPage' title='Test Your knowledge'>
           <TestPage 
-            words={this.state.knownWords}
+            language={this.state.knownWords.foreignLang}
             transMode={this.state.translationMode}
             switchModeClick={this.switchModeHandler}
             userAns={this.state.userAnswer}

--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,7 @@ class App extends React.Component {
     translationMode : 'fromEng', 
     userAnswer: '',
     sentences: rndSentence(wordList), 
-    tabToShow: 'WordList',
+    tabToShow: 'testPage',
     savedTexts: '',
     text: '',
     title: '',

--- a/src/Assets/Vocab.js
+++ b/src/Assets/Vocab.js
@@ -146,6 +146,7 @@ hot.foreign = ['horky', 'horka', 'horke'];
 
 
 export var wordList = {
+    foreignLang : 'Czech',
     defArticle : {english: 'The', foreign: {male:'Ten', female:'Ta', neuter:'To'}},
     nouns : [beer, wine, dog, table, banana, woman, man, tree, bed, car, gift, hospital, night],
     verbs : [toBe, toDo],

--- a/src/Components/TestPage.css
+++ b/src/Components/TestPage.css
@@ -1,6 +1,6 @@
 #chooseMode {
     margin: auto;
-    width: 70vmin;
+    width: 90vmin;
 }
 
 #question {
@@ -8,7 +8,7 @@
     color: white;
     font-size: 20px;
     margin: auto;
-    width: 70vmin;
+    width: 80vmin;
     border: 2px solid black;
     border-radius: 25%;
 }
@@ -17,7 +17,7 @@
     background: lightgray;
     font-size: 20px;
     margin: auto;
-    width: 70vmin;
+    width: 80vmin;
     border: 2px solid black;
     border-radius: 25%;
 }

--- a/src/Components/TestPage.css
+++ b/src/Components/TestPage.css
@@ -22,6 +22,12 @@
     border-radius: 25%;
 }
 
+Form {
+    width: 80vmin;
+    margin: auto;
+    padding: 10px;
+}
+
 .goodWord {
     color:green;
 }

--- a/src/Components/TestPage.css
+++ b/src/Components/TestPage.css
@@ -1,4 +1,4 @@
-#chooseMode {
+#testpage {
     margin: auto;
     width: 90vmin;
 }

--- a/src/Components/TestPage.js
+++ b/src/Components/TestPage.js
@@ -8,9 +8,11 @@ const TestPage = (props) => {
   if (props.transMode === 'fromEng') {
       var questionSentence = props.testQ.english;
       var answerSentence = props.testQ.foreign;
+      var placeHolderText = 'Provide the '+props.language+' translation';
     } else {
         questionSentence = props.testQ.foreign;
         answerSentence = props.testQ.english;
+        placeHolderText = 'Provide the English translation';
   }   
 
   var answerWords = answerSentence.toLowerCase().split(' ');
@@ -27,8 +29,12 @@ const TestPage = (props) => {
       <div id='testpage'>
         <h2>Translate the following</h2>
         <p id='question'>{questionSentence}</p>
+        <input 
+          type='text' 
+          placeholder={placeHolderText}
+          value={props.userAns} 
+          onChange={props.changeAns} />
         <div id='answer'>{markedAns}</div>
-        <input type='text' value={props.userAns} onChange={props.changeAns} />
         <Button variant='primary' onClick={props.switchModeClick}>Translate the other way</Button>
       </div>
   )

--- a/src/Components/TestPage.js
+++ b/src/Components/TestPage.js
@@ -16,7 +16,7 @@ const TestPage = (props) => {
   }   
 
   var answerWords = answerSentence.toLowerCase().split(' ');
-  var markedAns = props.userAns === '' ? <span>Give an Answer</span> 
+  var markedAns = props.userAns === '' ? <span>I'll mark your answer here</span> 
       : props.userAns.split(' ').map((x, i) => {
         if (x.toLowerCase() === answerWords[i]) {
             return <span className='goodWord' key={i}>{x+' '}</span>
@@ -39,7 +39,11 @@ const TestPage = (props) => {
           </Form.Group>
         </Form>
         <div id='answer'>{markedAns}</div>
+        <p></p>
         <Button variant='primary' onClick={props.switchModeClick}>Translate the other way</Button>
+        <p>If your translation matches what I'm thinking of, then your words will be green. 
+          If a word is red, then that is not what I am thinking of. 
+          If you get the complete sentence, I will reward you with a new question!</p>
       </div>
   )
 }

--- a/src/Components/TestPage.js
+++ b/src/Components/TestPage.js
@@ -29,11 +29,15 @@ const TestPage = (props) => {
       <div id='testpage'>
         <h2>Translate the following</h2>
         <p id='question'>{questionSentence}</p>
-        <input 
-          type='text' 
-          placeholder={placeHolderText}
-          value={props.userAns} 
-          onChange={props.changeAns} />
+        <Form>
+          <Form.Group>
+            <Form.Control 
+              type='text' 
+              placeholder={placeHolderText}
+              value={props.userAns} 
+              onChange={props.changeAns} />
+          </Form.Group>
+        </Form>
         <div id='answer'>{markedAns}</div>
         <Button variant='primary' onClick={props.switchModeClick}>Translate the other way</Button>
       </div>

--- a/src/Components/TestPage.js
+++ b/src/Components/TestPage.js
@@ -1,5 +1,7 @@
 import React from 'react';
-import './TestPage.css'
+import './TestPage.css';
+import {Button, Form} from  'react-bootstrap';
+import 'bootstrap/dist/css/bootstrap.css';
 
 const TestPage = (props) => {  
     
@@ -27,7 +29,7 @@ const TestPage = (props) => {
         <p id='question'>{questionSentence}</p>
         <div id='answer'>{markedAns}</div>
         <input type='text' value={props.userAns} onChange={props.changeAns} />
-        <button onClick={props.switchModeClick}>Translate the other way</button>
+        <Button variant='primary' onClick={props.switchModeClick}>Translate the other way</Button>
       </div>
   )
 }


### PR DESCRIPTION
- I made the test page the opening page when the app is loaded.
- I've given the user instructions on the test page. 
- The input box is clearer and contains placeholder text which tells you which language to type in. 
- The way in which the answer is marked is described in text at the bottom of the page. 
- I spread the elements out a bit so it looks better. 
- Input box and button are now bootstrap elements so they match the wordlist page.