### PR TITLE
prevent page reload by enter pressed in test form

### DIFF
--- a/src/Components/TestPage.js
+++ b/src/Components/TestPage.js
@@ -24,12 +24,17 @@ const TestPage = (props) => {
         return <span className='badWord' key={i}>{x+' '}</span>
         })
 
+  const handleSubmit = (event) => {
+    event.preventDefault();
+  }
+  
+
   
   return (
       <div id='testpage'>
         <h2>Translate the following</h2>
         <p id='question'>{questionSentence}</p>
-        <Form>
+        <Form onSubmit={handleSubmit} >
           <Form.Group>
             <Form.Control 
               type='text' 


### PR DESCRIPTION
I found that the page would reload when the user pressed the enter key while answering a test question. (Because it's part of a form, and so would submit). I have now prevented this default action.